### PR TITLE
1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The following list shows how much each modifier counts towards an item's worth
 - Enchantments: **85%**
   → Overload, Soul Eater, Inferno, Fatal Tempo: **35%**
   → Counter Strike: **20%**
+- Attributes: **100%**
+  → Based off the corresponding attribute shard's price
+  → Lava Fishing rods and Crimson Hunter set use their base item's price instead
 - Hot Potato Books: **100%**
 - Fuming Potato Books: **60%**
 - Art of War: **60%**

--- a/calculators/itemCalculator.js
+++ b/calculators/itemCalculator.js
@@ -376,6 +376,8 @@ const calculateItem = (item, prices) => {
           });
         }
 
+        // UNLOCKED GEMSTONE SLOTS
+        // Currently just gemstone chambers
         if (['divan_helmet', 'divan_chestplate', 'divan_leggings', 'divan_boots'].includes(itemId)) {
           const gemstoneSlots = JSON.parse(JSON.stringify(skyblockItem.gemstone_slots));
           for (const unlockedSlot of unlockedSlots) {
@@ -402,6 +404,7 @@ const calculateItem = (item, prices) => {
           }
         }
 
+        // GEMSTONES
         for (const gemstone of gems) {
           const calculationData = {
             id: `${gemstone.tier}_${gemstone.type}_GEM`,

--- a/calculators/itemCalculator.js
+++ b/calculators/itemCalculator.js
@@ -376,6 +376,30 @@ const calculateItem = (item, prices) => {
           });
         }
 
+        const gemstoneSlots = JSON.parse(JSON.stringify(skyblockItem.gemstone_slots));
+        for (const unlockedSlot of unlockedSlots) {
+          const slot = gemstoneSlots.find((s) => s.slot_type === unlockedSlot);
+          const slotIndex = gemstoneSlots.findIndex((s) => s.slot_type === unlockedSlot);
+          if (slotIndex > -1) {
+            let total = 0;
+            for (const cost of slot.costs || []) {
+              if (cost.type === 'COINS') total += cost.coins;
+              else if (cost.type === 'ITEM') total += (prices[cost.item_id.toLowerCase()] || 0) * cost.amount;
+            }
+
+            const calculationData = {
+              id: `${unlockedSlot}`,
+              type: 'gemstone_slot',
+              price: total * applicationWorth.gemstone_slots,
+              count: 1,
+            };
+            price += calculationData.price;
+            calculation.push(calculationData);
+
+            gemstoneSlots.splice(slotIndex, 1);
+          }
+        }
+
         for (const gemstone of gems) {
           const calculationData = {
             id: `${gemstone.tier}_${gemstone.type}_GEM`,
@@ -459,19 +483,6 @@ const calculateItem = (item, prices) => {
         price += calculationData.price;
         calculation.push(calculationData);
       }
-    }
-
-    // GEMSTONE CHAMBERS
-    if (ExtraAttributes.gemstone_slots || ['divan_chestplate', 'divan_leggings', 'divan_boots', 'divan_helmet'].includes(itemId)) {
-      const gemstoneSlotAmount = ExtraAttributes.gemstone_slots ? ExtraAttributes.gemstone_slots : ExtraAttributes.gems?.unlocked_slots ? ExtraAttributes.gems.unlocked_slots.length : 0;
-      const calculationData = {
-        id: 'GEMSTONE_CHAMBER',
-        type: 'gemstone_chamber',
-        price: (prices['gemstone_chamber'] || 0) * gemstoneSlotAmount * applicationWorth.gemstoneChamber,
-        count: gemstoneSlotAmount,
-      };
-      price += calculationData.price;
-      calculation.push(calculationData);
     }
 
     // DRILLS

--- a/calculators/itemCalculator.js
+++ b/calculators/itemCalculator.js
@@ -3,7 +3,7 @@ const { titleCase } = require('../helper/functions');
 const { getPetLevel } = require('../constants/pets');
 const { prestiges } = require('../constants/prestiges');
 const { applicationWorth, enchantsWorth } = require('../constants/applicationWorth');
-const { blockedEnchants, ignoredEnchants, stackingEnchants, ignoreSilex, masterStars, thunderCharge, validRunes, allowedRecombTypes, allowedRecombIds } = require('../constants/misc');
+const { blockedEnchants, ignoredEnchants, stackingEnchants, ignoreSilex, masterStars, thunderCharge, validRunes, allowedRecombTypes, allowedRecombIds, attributesBaseCosts } = require('../constants/misc');
 const { reforges } = require('../constants/reforges');
 const skyblockItems = require('../constants/items.json');
 
@@ -182,6 +182,28 @@ const calculateItem = (item, prices) => {
           price += calculationData.price;
           calculation.push(calculationData);
         }
+      }
+    }
+
+    if (ExtraAttributes.attributes) {
+      for (const [attribute, tier] of Object.entries(ExtraAttributes.attributes)) {
+        if (tier === 1) continue;
+        // Base price times the amount needed to get that tier which is 2^tier - 1 because of the base item
+        const shards = 2 ** (tier - 1) - 1;
+        let baseAttributePrice = prices[`attribute_shard_${attribute}`];
+        if (attributesBaseCosts[itemId] && prices[attributesBaseCosts[itemId]] < baseAttributePrice) {
+          baseAttributePrice = prices[attributesBaseCosts[itemId]];
+        }
+        const attributePrice = baseAttributePrice * shards * applicationWorth.attributes;
+
+        price += attributePrice;
+        calculation.push({
+          id: `${attribute}_${tier}`.toUpperCase(),
+          type: 'attribute',
+          price: attributePrice,
+          count: 1,
+          shards,
+        });
       }
     }
 

--- a/calculators/itemCalculator.js
+++ b/calculators/itemCalculator.js
@@ -376,27 +376,29 @@ const calculateItem = (item, prices) => {
           });
         }
 
-        const gemstoneSlots = JSON.parse(JSON.stringify(skyblockItem.gemstone_slots));
-        for (const unlockedSlot of unlockedSlots) {
-          const slot = gemstoneSlots.find((s) => s.slot_type === unlockedSlot);
-          const slotIndex = gemstoneSlots.findIndex((s) => s.slot_type === unlockedSlot);
-          if (slotIndex > -1) {
-            let total = 0;
-            for (const cost of slot.costs || []) {
-              if (cost.type === 'COINS') total += cost.coins;
-              else if (cost.type === 'ITEM') total += (prices[cost.item_id.toLowerCase()] || 0) * cost.amount;
+        if (['divan_helmet', 'divan_chestplate', 'divan_leggings', 'divan_boots'].includes(itemId)) {
+          const gemstoneSlots = JSON.parse(JSON.stringify(skyblockItem.gemstone_slots));
+          for (const unlockedSlot of unlockedSlots) {
+            const slot = gemstoneSlots.find((s) => s.slot_type === unlockedSlot);
+            const slotIndex = gemstoneSlots.findIndex((s) => s.slot_type === unlockedSlot);
+            if (slotIndex > -1) {
+              let total = 0;
+              for (const cost of slot.costs || []) {
+                if (cost.type === 'COINS') total += cost.coins;
+                else if (cost.type === 'ITEM') total += (prices[cost.item_id.toLowerCase()] || 0) * cost.amount;
+              }
+
+              const calculationData = {
+                id: `${unlockedSlot}`,
+                type: 'gemstone_slot',
+                price: total * applicationWorth.gemstoneSlots,
+                count: 1,
+              };
+              price += calculationData.price;
+              calculation.push(calculationData);
+
+              gemstoneSlots.splice(slotIndex, 1);
             }
-
-            const calculationData = {
-              id: `${unlockedSlot}`,
-              type: 'gemstone_slot',
-              price: total * applicationWorth.gemstone_slots,
-              count: 1,
-            };
-            price += calculationData.price;
-            calculation.push(calculationData);
-
-            gemstoneSlots.splice(slotIndex, 1);
           }
         }
 

--- a/calculators/sacksCalculator.js
+++ b/calculators/sacksCalculator.js
@@ -1,12 +1,13 @@
 const skyblockItems = require('../constants/items.json');
 const { validRunes } = require('../constants/misc');
+const { titleCase } = require('../helper/functions');
 
 const calculateSackItem = (item, prices) => {
   const itemPrice = prices[item.id.toLowerCase()] || 0;
   if (item.id.startsWith('RUNE_') && !validRunes.includes(item.id)) return null;
   if (itemPrice) {
     return {
-      name: skyblockItems.find((skyblockItem) => skyblockItem.id === item.id)?.name || 'Unknown',
+      name: item.name || skyblockItems.find((skyblockItem) => skyblockItem.id === item.id)?.name || titleCase(item.id),
       id: item.id,
       price: itemPrice * item.amount,
       calculation: [],

--- a/constants/applicationWorth.js
+++ b/constants/applicationWorth.js
@@ -16,10 +16,11 @@ const applicationWorth = {
   enrichment: 0.75,
   recomb: 0.8,
   gemstone: 1,
+  // TODO: adjust to @Head Hunter's liking
+  gemstone_slots: 0.8,
   reforge: 1,
   masterStar: 1,
   necronBladeScroll: 1,
-  gemstoneChamber: 0.9,
   drillPart: 1,
   etherwarp: 1,
   thunderInABottle: 0.8,

--- a/constants/applicationWorth.js
+++ b/constants/applicationWorth.js
@@ -16,8 +16,7 @@ const applicationWorth = {
   enrichment: 0.75,
   recomb: 0.8,
   gemstone: 1,
-  // TODO: adjust to @Head Hunter's liking
-  gemstone_slots: 0.8,
+  gemstoneSlots: 0.9,
   reforge: 1,
   masterStar: 1,
   necronBladeScroll: 1,

--- a/constants/applicationWorth.js
+++ b/constants/applicationWorth.js
@@ -26,6 +26,7 @@ const applicationWorth = {
   runes: 0.6,
   petItem: 1,
   petCandy: 0.65,
+  attributes: 1,
 };
 
 const enchantsWorth = {

--- a/constants/misc.js
+++ b/constants/misc.js
@@ -18,7 +18,19 @@ const thunderCharge = { UNCOMMON: 0, RARE: 150000, EPIC: 1000000, LEGENDARY: 500
 const validRunes = ['MUSIC_1', 'MUSIC_2', 'MUSIC_3', 'ENCHANT_1', 'ENCHANT_2', 'ENCHANT_3', 'GRAND_SEARING_3'];
 
 const allowedRecombTypes = ['ACCESSORY', 'NECKLACE', 'GLOVES', 'BRACELET', 'BELT', 'CLOAK'];
-const allowedRecombIds = ['DIVAN_HELMET', 'DIVAN_CHESTPLATE', 'DIVAN_LEGGINGS', 'DIVAN_BOOTS'];
+const allowedRecombIds = ['divan_helmet', 'divan_chestplate', 'divan_leggings', 'divan_boots'];
+
+const attributesBaseCosts = {
+  glowstone_gauntlet: 'glowstone_gauntlet',
+  vanquished_glowstone_gauntlet: 'glowstone_gauntlet',
+  blaze_belt: 'blaze_belt',
+  vanquished_blaze_belt: 'blaze_belt',
+  magma_necklace: 'magma_necklace',
+  vanquished_magma_necklace: 'magma_necklace',
+  magma_rod: 'magma_rod',
+  inferno_rod: 'magma_rod',
+  hellfire_rod: 'magma_rod',
+};
 
 module.exports = {
   blockedEnchants,
@@ -30,4 +42,5 @@ module.exports = {
   validRunes,
   allowedRecombTypes,
   allowedRecombIds,
+  attributesBaseCosts,
 };

--- a/helper/parseItems.js
+++ b/helper/parseItems.js
@@ -1,6 +1,7 @@
 const { parse, simplify } = require('prismarine-nbt');
 const { promisify } = require('util');
 const { getPetLevel } = require('../constants/pets');
+const { titleCase } = require('./functions');
 const parseNbt = promisify(parse);
 
 const singleContainers = {
@@ -22,6 +23,11 @@ const parseItems = async (profileData) => {
     for (const [id, amount] of Object.entries(profileData.sacks_counts)) {
       if (amount) items.sacks.push({ id, amount });
     }
+  }
+
+  // Parse Essence
+  for (const id of Object.keys(profileData)) {
+    if (id.startsWith('essence_')) items.sacks.push({ id, amount: profileData[id], name: `${titleCase(id.split('_')[1])} Essence` });
   }
 
   // Parse Single Containers (Armor, Equipment, Wardrobe, Inventory, Enderchest, Personal Vault)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyhelper-networth",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "SkyHelper's Networth Calculation for Hypixel SkyBlock",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Added profile essence (to sacks for now)
- Switched gemstone chambers to use unlocked slots for armor
- Added attributes on items (adds ~500m to Refraction's networth)
All items except lava fishing rods and crimson hunter set use their corresponding attribute shard prices times the amount needed to get that tier attribute. The exceptions use the base item's price or the corresponding attribute shard price (whichever is lower).