### PR TITLE
fix: error caused by pre decoded petInfo

### DIFF
--- a/helper/calculateNetworth.js
+++ b/helper/calculateNetworth.js
@@ -58,7 +58,7 @@ const calculateNetworth = (items, purseBalance, bankBalance, prices, onlyNetwort
 const calculateItemNetworth = (item, prices) => {
   const isPet = item.tag?.ExtraAttributes?.petInfo || item.exp;
   if (isPet) {
-    const petInfo = item.tag?.ExtraAttributes?.petInfo ? JSON.parse(item.tag.ExtraAttributes.petInfo) : item;
+    const petInfo = typeof item.tag?.ExtraAttributes?.petInfo === "object" ? item.tag?.ExtraAttributes?.petInfo : item.tag?.ExtraAttributes?.petInfo ? JSON.parse(item.tag.ExtraAttributes.petInfo) : item;
     const level = getPetLevel(petInfo);
     petInfo.level = level.level;
     petInfo.xpMax = level.xpMax;


### PR DESCRIPTION
## Description

TL;DR We're adding item value in description of item on SkyCrypt and we already parsed petInfo as JSON and that breaks things
![image](https://user-images.githubusercontent.com/75372052/210006752-141911fd-9715-4ece-8509-075b6813b5e2.png)
