### PR TITLE
fix(itemCalculator): enrichments price counted as 0

### DIFF
--- a/calculators/itemCalculator.js
+++ b/calculators/itemCalculator.js
@@ -408,7 +408,7 @@ const calculateItem = (item, prices, returnItemData) => {
 
     // ENRICHMENTS
     if (ExtraAttributes.talisman_enrichment) {
-      const enrichmentPrice = enrichments.reduce((acc, val) => Math.min(acc, prices[val] || 0), Infinity);
+      const enrichmentPrice = enrichments.reduce((acc, val) => Math.min(acc, prices[val.toLowerCase()] || 0), Infinity);
       if (enrichmentPrice !== Infinity) {
         const calculationData = {
           id: ExtraAttributes.talisman_enrichment.toUpperCase(),


### PR DESCRIPTION
## Description

Fixes a bug where price of accessory enrichment would be 0

## Preview
> Before
```
{
  name: 'Infernal Kuudra Core',
  loreName: '§dInfernal Kuudra Core',
  id: 'infernal_kuudra_core',
  price: 1309484233.2,
  base: 1300000000,
  calculation: [
    { id: 'STRENGTH', type: 'talisman_enrichment', price: 0, count: 1 },
    {
      id: 'RECOMBOBULATOR_3000',
      type: 'recombobulator_3000',
      price: 9484233.200000001,
      count: 1
    }
  ],
  count: 1,
  soulbound: false
}
```

> After
```
{
  name: 'Infernal Kuudra Core',
  loreName: '§dInfernal Kuudra Core',
  id: 'infernal_kuudra_core',
  price: 1312383733.2,
  base: 1300000000,
  calculation: [
    {
      id: 'STRENGTH',
      type: 'talisman_enrichment',
      price: 2899500,
      count: 1
    },
    {
      id: 'RECOMBOBULATOR_3000',
      type: 'recombobulator_3000',
      price: 9484233.200000001,
      count: 1
    }
  ],
  count: 1,
  soulbound: false
}
```