### PR TITLE
fix(itemCalculator): Stonk's SIL_EX price being 0

### DIFF
--- a/calculators/itemCalculator.js
+++ b/calculators/itemCalculator.js
@@ -220,14 +220,19 @@ const calculateItem = (item, prices, returnItemData) => {
 
         // SILEX
         if (name === 'efficiency' && value > 5 && !ignoreSilex.includes(itemId)) {
-          const calculationData = {
-            id: 'SIL_EX',
-            type: 'silex',
-            price: (prices['sil_ex'] || 0) * (value - (itemId === 'stonk_pickaxe' ? 6 : 5)) * applicationWorth.silex,
-            count: 1,
-          };
-          price += calculationData.price;
-          calculation.push(calculationData);
+          const efficiencyLevel = value - (itemId === 'stonk_pickaxe' ? 6 : 5);
+          
+          if (efficiencyLevel > 0) {
+            const calculationData = {
+              id: 'SIL_EX',
+              type: 'silex',
+              price: (prices['sil_ex'] || 0) * efficiencyLevel * applicationWorth.silex,
+              count: 1,
+            };
+            price += calculationData.price;
+            calculation.push(calculationData);
+          }
+
         }
 
         const calculationData = {


### PR DESCRIPTION
## Description

Fixed Silex being applied to Stonk's NW calculation even tho it's not applied / affected by it at all

> Before
```js
{
  name: 'Stonk',
  loreName: '§5Stonk',
  id: 'stonk_pickaxe',
  price: 500000,
  base: 500000,
  calculation: [ { id: 'SIL_EX', type: 'silex', price: 0, count: 1 } ],
  count: 1,
  soulbound: false
}
```

> After
```js
{
  name: 'Stonk',
  loreName: '§5Stonk',
  id: 'stonk_pickaxe',
  price: 500000,
  base: 500000,
  calculation: [],
  count: 1,
  soulbound: false
}
```