### PR TITLE
fix: IDs being cut out

### DIFF
--- a/calculators/itemCalculator.js
+++ b/calculators/itemCalculator.js
@@ -151,7 +151,7 @@ const calculateItem = (item, prices, returnItemData) => {
       const godRollId = `${itemId.replace(/(hot_|fiery_|burning_|infernal_)/g, "")}${sortedAttributes.map((attribute) => `_roll_${attribute.toLowerCase()}`).join('')}`;
       const godRollPrice = prices[godRollId];
       if (godRollPrice > price) {
-        price += godRollPrice;
+        price = godRollPrice;
         base = godRollPrice;
         calculation.push({
           id: godRollId.slice(itemId.replace(/(hot_|fiery_|burning_|infernal_)/g, "").length + 1),

--- a/calculators/itemCalculator.js
+++ b/calculators/itemCalculator.js
@@ -151,10 +151,10 @@ const calculateItem = (item, prices, returnItemData) => {
       const godRollId = `${itemId.replace(/(hot_|fiery_|burning_|infernal_)/g, "")}${sortedAttributes.map((attribute) => `_roll_${attribute.toLowerCase()}`).join('')}`;
       const godRollPrice = prices[godRollId];
       if (godRollPrice > price) {
-        price = godRollPrice;
+        price += godRollPrice;
         base = godRollPrice;
         calculation.push({
-          id: godRollId.slice(itemId.length + 1),
+          id: godRollId.slice(itemId.replace(/(hot_|fiery_|burning_|infernal_)/g, "").length + 1),
           type: 'god_roll',
           price: godRollPrice,
           count: 1,

--- a/calculators/itemCalculator.js
+++ b/calculators/itemCalculator.js
@@ -150,9 +150,8 @@ const calculateItem = (item, prices, returnItemData) => {
       const sortedAttributes = Object.keys(ExtraAttributes.attributes).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
       const godRollId = `${itemId.replace(/(hot_|fiery_|burning_|infernal_)/g, "")}${sortedAttributes.map((attribute) => `_roll_${attribute.toLowerCase()}`).join('')}`;
       const godRollPrice = prices[godRollId];
-      if (godRollPrice > price) {
-        price = godRollPrice;
-        base = godRollPrice;
+      if (godRollPrice > 0) {
+        price += godRollPrice;
         calculation.push({
           id: godRollId.slice(itemId.replace(/(hot_|fiery_|burning_|infernal_)/g, "").length + 1),
           type: 'god_roll',


### PR DESCRIPTION
> Example
![image](https://github.com/Altpapier/SkyHelper-Networth/assets/75372052/54370358-0bf8-48a6-948f-c7af184a183c)
