### PR TITLE
fix: `isPet` being `0`

### DIFF
--- a/helper/calculateNetworth.js
+++ b/helper/calculateNetworth.js
@@ -64,7 +64,7 @@ const calculateNetworth = (items, purseBalance, bankBalance, prices, onlyNetwort
 
 const calculateItemNetworth = (item, prices, returnItemNetworth) => {
   const isPet = item.tag?.ExtraAttributes?.petInfo || item.exp;
-  if (isPet) {
+  if (isPet !== undefined) {
     const petInfo = item.tag?.ExtraAttributes?.petInfo ? JSON.parse(item.tag.ExtraAttributes.petInfo) : item;
     const level = getPetLevel(petInfo);
     petInfo.level = level.level;


### PR DESCRIPTION
## Description

Fixes case when lvl 1 pet's value doesn't get calculated if `item.tag?.ExtraAttributes?.petInfo` is undefined (when pet is from pet's menu) & when `item.exp` is 0 (when pet has 0 experience)