### PR TITLE
fix(ts-types): Added missing types that have been added

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,19 @@
 declare module "skyhelper-networth" {
   export interface NetworthOptions {
+    v2Endpoint?: boolean;
     cache?: boolean;
     onlyNetworth?: boolean;
     prices?: object;
     returnItemData?: boolean;
     museumData?: object;
+  }
+
+  export interface PreDecodedNetworthOptions {
+    v2Endpoint?: boolean;
+    cache?: boolean;
+    onlyNetworth?: boolean;
+    prices?: object;
+    returnItemData?: boolean;
   }
 
   export interface ItemNetworthOptions {
@@ -88,7 +97,7 @@ declare module "skyhelper-networth" {
     profileData: object,
     items: object,
     bankBalance: number,
-    options?: NetworthOptions
+    options?: PreDecodedNetworthOptions
   ): Promise<NetworthResult>;
 
   export function getItemNetworth(


### PR DESCRIPTION
Added missing types that wont there and that caused my some problems when building with typescript.

Should [L:39](https://github.com/Altpapier/SkyHelper-Networth/blob/master/index.js#L39) in index.js have the `museumData` option be there?