### PR TITLE
fix: patch item type import

### DIFF
--- a/types/ProfileNetworthCalculator.d.ts
+++ b/types/ProfileNetworthCalculator.d.ts
@@ -1,5 +1,4 @@
-import { Item } from './SkyBlockItemNetworthCalculator';
-import { NetworthOptions } from './global';
+import { NetworthOptions, Item } from './global';
 
 interface NetworthResult {
     /**


### PR DESCRIPTION
Type `Item` was incorrectly imported. This would break, for example, `tsoa` type definition, as that type cannot be found.

Tests pass, and so does the TypeScript compiler.

Also, I would recommend putting TypeScript as a devDependency instead of using the global one. It ensures the contributors know which version to install to avoid issues and gets rid of the "it works on my machine" bug.