### PR TITLE
feat: pnpm check on checkForUpdates

### DIFF
--- a/managers/UpdateManager.js
+++ b/managers/UpdateManager.js
@@ -54,9 +54,16 @@ class UpdateManager {
         try {
             const packageInfo = await axios.get('https://registry.npmjs.org/skyhelper-networth');
             const latestVersion = packageInfo.data['dist-tags'].latest;
+            const packageInstallAgent = process.env.npm_config_user_agent ?? 'unknown/0.0.0 node/v0.0.0 linux x64';
+            const releaseTime = new Date(packageInfo.data.time[latestVersion]).getTime()
+            const currentTime = Date.now()
             const currentVersion = require('../package.json').version;
             const [latestMajor, latestMinor, latestPatch] = latestVersion.split('.').map(Number);
             const [currentMajor, currentMinor, currentPatch] = currentVersion.split('.').map(Number);
+
+            // Since pnpm v11 it won't install packages newer then a day by default. This is designed to help stop supply chain attacks
+            // Alerting a user of a package release that they cannot install will just be annoying and clutter logs
+            if (packageInstallAgent.startsWith("pnpm/") && (releaseTime + (24 * 60 * 60 * 1000)) >= currentTime) return;
 
             if (latestMajor > currentMajor) {
                 console.warn(

--- a/managers/UpdateManager.js
+++ b/managers/UpdateManager.js
@@ -55,15 +55,15 @@ class UpdateManager {
             const packageInfo = await axios.get('https://registry.npmjs.org/skyhelper-networth');
             const latestVersion = packageInfo.data['dist-tags'].latest;
             const packageInstallAgent = process.env.npm_config_user_agent ?? 'unknown/0.0.0 node/v0.0.0 linux x64';
-            const releaseTime = new Date(packageInfo.data.time[latestVersion]).getTime()
-            const currentTime = Date.now()
+            const releaseTime = new Date(packageInfo.data.time[latestVersion]).getTime();
+            const currentTime = Date.now();
             const currentVersion = require('../package.json').version;
             const [latestMajor, latestMinor, latestPatch] = latestVersion.split('.').map(Number);
             const [currentMajor, currentMinor, currentPatch] = currentVersion.split('.').map(Number);
 
             // Since pnpm v11 it won't install packages newer then a day by default. This is designed to help stop supply chain attacks
             // Alerting a user of a package release that they cannot install will just be annoying and clutter logs
-            if (packageInstallAgent.startsWith("pnpm/") && (releaseTime + (24 * 60 * 60 * 1000)) >= currentTime) return;
+            if (packageInstallAgent.startsWith('pnpm/') && releaseTime + 24 * 60 * 60 * 1000 >= currentTime) return;
 
             if (latestMajor > currentMajor) {
                 console.warn(

--- a/tests/UpdateManager.test.js
+++ b/tests/UpdateManager.test.js
@@ -79,7 +79,7 @@ describe('UpdateManager', () => {
     describe('Update Checking', () => {
         test('should warn about major version update', async () => {
             axios.get.mockResolvedValueOnce({
-                data: { 'dist-tags': { latest: '2.0.0' } },
+                data: { 'dist-tags': { latest: '2.0.0' }, 'time': { '2.0.0': '2025-03-23T11:03:18.811Z' } },
             });
 
             await UpdateManager.checkForUpdate();
@@ -90,7 +90,7 @@ describe('UpdateManager', () => {
 
         test('should warn about minor version update', async () => {
             axios.get.mockResolvedValueOnce({
-                data: { 'dist-tags': { latest: '1.1.0' } },
+                data: { 'dist-tags': { latest: '1.1.0' }, 'time': { '1.1.0': '2022-09-28T18:11:13.755Z' } },
             });
 
             await UpdateManager.checkForUpdate();
@@ -101,7 +101,7 @@ describe('UpdateManager', () => {
 
         test('should warn about patch version update', async () => {
             axios.get.mockResolvedValueOnce({
-                data: { 'dist-tags': { latest: '1.0.1' } },
+                data: { 'dist-tags': { latest: '1.0.1' }, 'time': { '1.0.1': '2022-09-11T12:51:42.374Z' } },
             });
 
             await UpdateManager.checkForUpdate();
@@ -112,7 +112,7 @@ describe('UpdateManager', () => {
 
         test('should not warn when on latest version', async () => {
             axios.get.mockResolvedValueOnce({
-                data: { 'dist-tags': { latest: '1.0.0' } },
+                data: { 'dist-tags': { latest: '1.0.0' }, 'time': { '1.0.1': '2022-09-11T10:16:32.508Z' } },
             });
 
             await UpdateManager.checkForUpdate();


### PR DESCRIPTION
Since pnpm v11 there is a `minimumReleaseAge` setting that is enabled and set to 24h by default. Adding a check that the package was installed using pnpm and then assuming that the `minimumReleaseAge` setting is on and using the default values. This check will need to pass before it alerts the user of a new release. Having it alert the user of a new release before it's installable will just annoy the user and clutter up the logs